### PR TITLE
Fixed sidebar navigation arrow direction when opening menu

### DIFF
--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -146,6 +146,8 @@ const LinkList = styled(List)`
 
 const CollapseMenuItem = styled(MenuItemButton)`
   display: none;
+  transform: ${({ isCollapsed }) =>
+    isCollapsed ? "rotate(180deg)" : "rotate(0deg)"};
 
   @media (min-width: ${breakpoint("desktop")}) {
     display: flex;


### PR DESCRIPTION
Arrow now turns to the right when the menu is closed.